### PR TITLE
Add fallback support for ARM macs

### DIFF
--- a/lib/utils.bash
+++ b/lib/utils.bash
@@ -44,9 +44,9 @@ download_release() {
 
   local arch
   machine=$(uname -m)
-  if [[ $machine == "arm64" ]] || [[ $machine == "aarch64" ]]; then
+  # circleci-cli provides arm64 builds only for Linux. For macOS, fallback to run amd64 arch via Rosetta
+  if [[ $platform == "linux" && ($machine == "arm64" || $machine == "aarch64") ]]; then
     arch="arm64"
-    echo "${TOOL_NAME} does not currently provide ${arch} builds" && exit 1
   elif [[ $machine == *"386"* ]]; then
     arch="386"
     echo "${TOOL_NAME} does not currently provide ${arch} builds" && exit 1


### PR DESCRIPTION
Hey @lukeab!

I wanted to add circleci-cli to my asdf setup. I was really excited to find your plugin, but it wouldn't install on a M1 MacBook with the "circleci does not currently provide arm64 builds" error. 

I've checked the build artefacts that CircleCI published https://github.com/CircleCI-Public/circleci-cli/releases, and indeed there were no arm64 builds for Macs. However, falling back to the amd64 architecture still works as macOS provides the translation mechanism for such binaries (Rosetta).

So in this pull request I'm suggesting to use arm64 builds for Linux machines and fallback to amd64 for Macs. I've tried this approach using a fork of your plugin and it works.

Please let me know what you think!

